### PR TITLE
Fix `exp(-inf)` being negative infinity

### DIFF
--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -1331,7 +1331,7 @@ impl BigFloat {
         exp,
         Self,
         { INF_POS },
-        { INF_NEG },
+        { Self::from_u8(0, p) },
         p,
         usize
     );
@@ -2091,7 +2091,7 @@ mod tests {
             assert!(op(&NAN, rand_p(), rm, &mut cc).is_nan());
         }
 
-        assert!(INF_NEG.exp(rand_p(), rm, &mut cc).is_inf_neg());
+        assert!(INF_NEG.exp(rand_p(), rm, &mut cc).is_zero());
         assert!(INF_POS.exp(rand_p(), rm, &mut cc).is_inf_pos());
         assert!(NAN.exp(rand_p(), rm, &mut cc).is_nan());
 


### PR DESCRIPTION
`exp(neg inf)` should actually be zero.

Is this the proper way to create an instance of zero (like a global const or something). I just copied how I saw 1 being created somewhere else in the file.