### PR TITLE
Acosh atanh boundary

### DIFF
--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -1442,8 +1442,8 @@ impl BigFloat {
         Precision is rounded upwards to the word size. The function returns NaN if the precision `p` is incorrect.",
         atanh,
         Self,
-        { BigFloat::new(1) },
-        { BigFloat::new(1) },
+        { NAN },
+        { NAN },
         p,
         usize
     );
@@ -2142,8 +2142,8 @@ mod tests {
         assert!(INF_POS.acosh(rand_p(), rm, &mut cc).is_inf_pos());
         assert!(NAN.acosh(rand_p(), rm, &mut cc).is_nan());
 
-        assert!(INF_NEG.atanh(rand_p(), rm, &mut cc).is_zero());
-        assert!(INF_POS.atanh(rand_p(), rm, &mut cc).is_zero());
+        assert!(INF_NEG.atanh(rand_p(), rm, &mut cc).is_nan());
+        assert!(INF_POS.atanh(rand_p(), rm, &mut cc).is_nan());
         assert!(NAN.atanh(rand_p(), rm, &mut cc).is_nan());
 
         assert!(INF_NEG.reciprocal(rand_p(), rm).is_zero());

--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -1431,8 +1431,8 @@ impl BigFloat {
         Precision is rounded upwards to the word size. The function returns NaN if the precision `p` is incorrect.",
         acosh,
         Self,
-        { BigFloat::new(1) },
-        { BigFloat::new(1) },
+        { INF_POS },
+        { NAN },
         p,
         usize
     );
@@ -2138,8 +2138,8 @@ mod tests {
         assert!(INF_POS.asinh(rand_p(), rm, &mut cc).is_inf_pos());
         assert!(NAN.asinh(rand_p(), rm, &mut cc).is_nan());
 
-        assert!(INF_NEG.acosh(rand_p(), rm, &mut cc).is_zero());
-        assert!(INF_POS.acosh(rand_p(), rm, &mut cc).is_zero());
+        assert!(INF_NEG.acosh(rand_p(), rm, &mut cc).is_nan());
+        assert!(INF_POS.acosh(rand_p(), rm, &mut cc).is_inf_pos());
         assert!(NAN.acosh(rand_p(), rm, &mut cc).is_nan());
 
         assert!(INF_NEG.atanh(rand_p(), rm, &mut cc).is_zero());


### PR DESCRIPTION
Hello it's me again. I've been writing tests for my library and it compares the results of this library and `f64`, some of the boundary conditions come out as not the same. I'll just pull request them as I find them I guess.

This one fixes boundary values for `acosh` and `atanh`.

In the original version, `acosh(-inf)`, `atanh(-inf)` and `atanh(inf)` were all defined as 1 (clearly a typo that got embedded in).

- `acosh(-inf)` is not in the range of `acosh`.
- `acosh(inf)` is defined as `inf`.
- `atanh`'s domain is `(-1,1)` so it is not defined for either negative infinity or positive infinity and should return `NaN`.

Also changes tests to match the real values.