### PR TITLE
fix: use target_pointer_width for word size selection (fixes #39)

### DIFF
--- a/.github/workflows/2-tests.yml
+++ b/.github/workflows/2-tests.yml
@@ -21,7 +21,7 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-26-intel
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/2-tests.yml
+++ b/.github/workflows/2-tests.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/2-tests.yml
+++ b/.github/workflows/2-tests.yml
@@ -10,13 +10,48 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-and-test-x64:
+  build-and-test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run tests
       run: cargo test --workspace --release --verbose
     - name: Run no_std tests
       run: cargo test --workspace --release --verbose --no-default-features --features random,serde
+
+  build-wasm32:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Add wasm32 target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build for wasm32
+      run: cargo build --package astro-float-num --target wasm32-unknown-unknown --no-default-features
+    - name: Build for wasm32 with features
+      run: cargo build --package astro-float-num --target wasm32-unknown-unknown --no-default-features --features serde
+
+  build-i686:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Add i686 target
+      run: rustup target add i686-unknown-linux-gnu
+    - name: Install 32-bit libs
+      run: sudo apt-get update && sudo apt-get install -y gcc-multilib
+    - name: Build for i686
+      run: cargo build --package astro-float-num --target i686-unknown-linux-gnu

--- a/.github/workflows/2-tests.yml
+++ b/.github/workflows/2-tests.yml
@@ -20,8 +20,12 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+          - os: macos-13
+            target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.os }}
 

--- a/astro-float-num/Cargo.toml
+++ b/astro-float-num/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/stencillogic/astro-float"
 rand = "0.8.5"
 serde_json = "1.0.89"
 
-[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dev-dependencies]
 rug = { version = "~1.20.0", features = ["float", "rand"] }
 gmp-mpfr-sys = { version = "~1.6.0", features = [] }
 

--- a/astro-float-num/src/conv.rs
+++ b/astro-float-num/src/conv.rs
@@ -57,7 +57,7 @@ impl BigFloatNumber {
             }
         }
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         if e < EXPONENT_MIN || e > EXPONENT_MAX {
             return Err(Error::InvalidArgument);
         }
@@ -830,7 +830,7 @@ mod tests {
         let n = BigFloatNumber::from_f64(64, -83.591552734375).unwrap();
         assert_eq!(n.cmp(&g), 0);
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             let n = BigFloatNumber::from_raw_parts(
                 &[2576980377, 2576980377, 2576980377],
@@ -891,7 +891,7 @@ mod tests {
             assert!(g.cmp(&n) == 0);
         }
 
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             let n = BigFloatNumber::from_raw_parts(
                 &[0x9999999999999999, 0x9999999999999999, 0x9999999999999999],

--- a/astro-float-num/src/defs.rs
+++ b/astro-float-num/src/defs.rs
@@ -9,46 +9,46 @@ use std::collections::TryReserveError;
 use alloc::collections::TryReserveError;
 
 /// A word.
-#[cfg(not(target_arch = "x86"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub type Word = u64;
 
 /// Doubled word.
-#[cfg(not(target_arch = "x86"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub type DoubleWord = u128;
 
 /// Word with sign.
-#[cfg(not(target_arch = "x86"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub type SignedWord = i128;
 
 /// A word.
-#[cfg(target_arch = "x86")]
+#[cfg(target_pointer_width = "32")]
 pub type Word = u32;
 
 /// Doubled word.
-#[cfg(target_arch = "x86")]
+#[cfg(target_pointer_width = "32")]
 pub type DoubleWord = u64;
 
 /// Word with sign.
-#[cfg(target_arch = "x86")]
+#[cfg(target_pointer_width = "32")]
 pub type SignedWord = i64;
 
 /// An exponent.
 pub type Exponent = i32;
 
 /// Maximum exponent value.
-#[cfg(not(target_arch = "x86"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub const EXPONENT_MAX: Exponent = Exponent::MAX;
 
 /// Maximum exponent value.
-#[cfg(target_arch = "x86")]
+#[cfg(target_pointer_width = "32")]
 pub const EXPONENT_MAX: Exponent = Exponent::MAX / 4;
 
 /// Minimum exponent value.
-#[cfg(not(target_arch = "x86"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub const EXPONENT_MIN: Exponent = Exponent::MIN;
 
 /// Minimum exponent value.
-#[cfg(target_arch = "x86")]
+#[cfg(target_pointer_width = "32")]
 pub const EXPONENT_MIN: Exponent = Exponent::MIN / 4;
 
 /// Maximum value of a word.

--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -2159,11 +2159,11 @@ mod tests {
         let d1 = ONE.clone();
         assert!(d1.exponent() == Some(1));
         let words: &[Word] = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 &[0, 0x8000000000000000]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 &[0, 0, 0, 0x80000000]
             }
@@ -2479,11 +2479,11 @@ mod rand_tests {
         for _ in 0..1000 {
             let p = rand::random::<usize>() % 1000 + DEFAULT_P;
             let exp_from;
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 exp_from = rand::random::<Exponent>().abs();
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 use crate::defs::EXPONENT_MIN;
                 exp_from =

--- a/astro-float-num/src/mantissa/mantissa.rs
+++ b/astro-float-num/src/mantissa/mantissa.rs
@@ -717,12 +717,12 @@ impl Mantissa {
         let nd = m.len() - size_of::<u64>() / size_of::<Word>();
         m[..nd].fill(0);
 
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             m[nd] = u;
         }
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             let mut u = u;
             for v in &mut m[nd..] {
@@ -764,12 +764,12 @@ impl Mantissa {
 
     #[cfg(test)]
     pub fn to_u64(&self) -> u64 {
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             self.m[self.m.len() - 1]
         }
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             let mut ret: u64 = 0;
             let nd = size_of::<u64>() / size_of::<Word>();

--- a/astro-float-num/src/num.rs
+++ b/astro-float-num/src/num.rs
@@ -166,12 +166,12 @@ impl BigFloatNumber {
     }
 
     pub(crate) fn from_u64_internal(d: u64, p: usize) -> Result<Self, Error> {
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             Self::from_word(d, p)
         }
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             Self::p_assertion(p)?;
 
@@ -551,7 +551,7 @@ impl BigFloatNumber {
         if self.is_subnormal() {
             let (shift, mantissa) = self.m.normilize()?;
 
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 // checks for the case when usize is larger than exponent
                 debug_assert!((shift as isize) < (isize::MAX / 2 + EXPONENT_MIN as isize));
@@ -673,7 +673,7 @@ impl BigFloatNumber {
 
         d3.inexact |= inexact;
 
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             debug_assert!(shift <= isize::MAX / 2 && e >= isize::MIN / 2);
         }
@@ -845,7 +845,7 @@ impl BigFloatNumber {
         ret.m = m;
         ret.e = exponent - 0b1111111111 - shift as Exponent;
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         debug_assert!(ret.e <= EXPONENT_MAX && ret.e >= EXPONENT_MIN);
 
         Ok(ret)
@@ -943,7 +943,7 @@ impl BigFloatNumber {
         let p = m.len() * WORD_BIT_SIZE;
         Self::p_assertion(p)?;
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         if e < EXPONENT_MIN || e > EXPONENT_MAX {
             return Err(Error::InvalidArgument);
         }
@@ -989,7 +989,7 @@ impl BigFloatNumber {
         let p = m.len() * WORD_BIT_SIZE;
         Self::p_assertion(p)?;
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         if e < EXPONENT_MIN || e > EXPONENT_MAX {
             return Err(Error::InvalidArgument);
         }
@@ -1175,7 +1175,7 @@ impl BigFloatNumber {
     /// Note that if `self` is subnormal, the exponent may not change, but the mantissa will shift instead.
     /// `e` will be clamped to the range from EXPONENT_MIN to EXPONENT_MAX if it's outside of the range.
     pub fn set_exponent(&mut self, e: Exponent) {
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         let e = if e < EXPONENT_MIN {
             EXPONENT_MIN
         } else if e > EXPONENT_MAX {
@@ -1314,7 +1314,7 @@ impl BigFloatNumber {
     pub fn random_normal(p: usize, exp_from: Exponent, exp_to: Exponent) -> Result<Self, Error> {
         Self::p_assertion(p)?;
 
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         if exp_from < EXPONENT_MIN || exp_to > EXPONENT_MAX {
             return Err(Error::InvalidArgument);
         }
@@ -2288,7 +2288,7 @@ mod tests {
             .unwrap();
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [
                     12297829382473034411,
@@ -2298,7 +2298,7 @@ mod tests {
                     12297829382473034410,
                 ]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [2863311531, 2863311530, 2863311530, 2863311530, 2863311530]
             }
@@ -2312,11 +2312,11 @@ mod tests {
             .unwrap();
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [12297829382473034411, 12297829382473034410, 12297829382473034410]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [2863311531, 2863311530, 2863311530]
             }
@@ -2328,11 +2328,11 @@ mod tests {
         d3 = d1.div(&d2, WORD_BIT_SIZE, RoundingMode::ToEven).unwrap();
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [12297829382473034411]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [2863311531]
             }
@@ -2405,7 +2405,7 @@ mod tests {
             .unwrap();
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [
                     12297829382473034411,
@@ -2415,7 +2415,7 @@ mod tests {
                     12297829382473034410,
                 ]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [2863311531, 2863311530, 2863311530, 2863311530, 2863311530]
             }
@@ -2426,11 +2426,11 @@ mod tests {
         d2 = d1.reciprocal(WORD_BIT_SIZE, RoundingMode::ToEven).unwrap();
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [12297829382473034411]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [2863311531]
             }
@@ -2861,14 +2861,14 @@ mod tests {
         assert_eq!(d1.sign(), Sign::Neg);
 
         let d1 = BigFloatNumber::from_words(&[3, 1], Sign::Pos, EXPONENT_MAX).unwrap();
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             assert_eq!(
                 d1.mantissa().digits(),
                 [0x8000000000000000u64, 0x8000000000000001u64]
             );
         }
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             assert_eq!(d1.mantissa().digits(), [0x80000000u32, 0x80000001u32]);
         }
@@ -2892,11 +2892,11 @@ mod tests {
         assert_eq!(d1.sign(), Sign::Pos);
 
         let words = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [3, 0x8000000000000000u64]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [3, 0x80000000u32]
             }
@@ -2933,7 +2933,7 @@ mod tests {
         // 1 1001
 
         let mantissas = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [
                     [0x8000000000000000u64, 0x8000000000000000u64],
@@ -2944,7 +2944,7 @@ mod tests {
                     [0x8000000000000019u64, 0x8000000000000000u64],
                 ]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [
                     [0x80000000u32, 0x80000000u32],
@@ -2958,7 +2958,7 @@ mod tests {
         };
 
         let rounding_results_posnum = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [
                     (RoundingMode::None, mantissas),
@@ -3030,7 +3030,7 @@ mod tests {
                     ),
                 ]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [
                     (RoundingMode::None, mantissas),
@@ -3105,7 +3105,7 @@ mod tests {
         };
 
         let rounding_results_negnum = {
-            #[cfg(not(target_arch = "x86"))]
+            #[cfg(not(target_pointer_width = "32"))]
             {
                 [
                     (RoundingMode::None, mantissas),
@@ -3177,7 +3177,7 @@ mod tests {
                     ),
                 ]
             }
-            #[cfg(target_arch = "x86")]
+            #[cfg(target_pointer_width = "32")]
             {
                 [
                     (RoundingMode::None, mantissas),

--- a/astro-float-num/src/ops/consts/e.rs
+++ b/astro-float-num/src/ops/consts/e.rs
@@ -136,7 +136,7 @@ mod tests {
     use crate::{RoundingMode, Sign};
 
     #[test]
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     fn test_e_const() {
         let mut e = ECache::new().unwrap();
         let c = e.for_prec(320, RoundingMode::ToEven).unwrap();
@@ -156,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(target_pointer_width = "32"))]
     fn test_e_const() {
         let mut e = ECache::new().unwrap();
         let c = e.for_prec(320, RoundingMode::ToEven).unwrap();

--- a/astro-float-num/src/ops/consts/ln10.rs
+++ b/astro-float-num/src/ops/consts/ln10.rs
@@ -133,7 +133,7 @@ mod tests {
     use crate::{RoundingMode, Sign};
 
     #[test]
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     fn test_ln10_const() {
         let mut ln10 = Ln10Cache::new().unwrap();
         let c = ln10.for_prec(320, RoundingMode::ToEven).unwrap();
@@ -153,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(target_pointer_width = "32"))]
     fn test_ln10_const() {
         let mut ln10 = Ln10Cache::new().unwrap();
         let c = ln10.for_prec(320, RoundingMode::ToEven).unwrap();

--- a/astro-float-num/src/ops/consts/ln2.rs
+++ b/astro-float-num/src/ops/consts/ln2.rs
@@ -137,7 +137,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     fn test_ln2_const() {
         let mut ln2 = Ln2Cache::new().unwrap();
         let c = ln2.for_prec(3200, RoundingMode::ToEven).unwrap();
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(target_pointer_width = "32"))]
     fn test_ln2_const() {
         let mut ln2 = Ln2Cache::new().unwrap();
         let c = ln2.for_prec(3200, RoundingMode::ToEven).unwrap();

--- a/astro-float-num/src/ops/consts/pi.rs
+++ b/astro-float-num/src/ops/consts/pi.rs
@@ -154,7 +154,7 @@ mod tests {
     use crate::{RoundingMode, Sign};
 
     #[test]
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     fn test_pi_const() {
         let mut pi = PiCache::new().unwrap();
         let c = pi.for_prec(320, RoundingMode::ToEven).unwrap();
@@ -174,7 +174,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(target_pointer_width = "32"))]
     fn test_pi_const() {
         let mut pi = PiCache::new().unwrap();
         let c = pi.for_prec(320, RoundingMode::ToEven).unwrap();

--- a/astro-float-num/src/ops/tests.rs
+++ b/astro-float-num/src/ops/tests.rs
@@ -896,11 +896,11 @@ fn test_tanh_atanh() {
     let mut cc = Consts::new().unwrap();
 
     let exp_to;
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(target_pointer_width = "32"))]
     {
         exp_to = 5;
     }
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     {
         exp_to = 3;
     }

--- a/astro-float-num/src/parser.rs
+++ b/astro-float-num/src/parser.rs
@@ -363,11 +363,11 @@ mod tests {
 
         // large exp
         let numstr;
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             numstr = "abc.def09123e_e+7FFFFFFF";
         }
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             numstr = "abc.def09123e_e+1FFFFFFF";
         }
@@ -376,11 +376,11 @@ mod tests {
         assert!(ps.sign().is_positive());
 
         let numstr;
-        #[cfg(not(target_arch = "x86"))]
+        #[cfg(not(target_pointer_width = "32"))]
         {
             numstr = "-abc.def09123e_e+7FFFFFFF";
         }
-        #[cfg(target_arch = "x86")]
+        #[cfg(target_pointer_width = "32")]
         {
             numstr = "-abc.def09123e_e+1FFFFFFF";
         }

--- a/astro-float-num/tests/integration_tests.rs
+++ b/astro-float-num/tests/integration_tests.rs
@@ -1,5 +1,5 @@
 //! Integration tests.
 
 #[cfg(test)]
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 mod mpfr;


### PR DESCRIPTION
## Summary

- Replace all `cfg(target_arch = "x86")` with `cfg(target_pointer_width = "32")` for word size selection across 11 source files
- CPU intrinsics in `common/util.rs` remain gated on `target_arch` (architecture-specific)
- Expand CI to test on Linux x64, Linux ARM, macOS, Windows, wasm32 (build), and i686 (build)

## Problem

On `wasm32-unknown-unknown`, `target_arch` is `"wasm32"`, not `"x86"`, so the crate used `Word = u64` despite `usize` being 32-bit. This caused `BigFloat::format()` to panic with an index-out-of-bounds error.

## Fix

Use `target_pointer_width = "32"` instead, which correctly matches all 32-bit platforms (x86, wasm32, arm32, etc.).

Fixes #39

## Test plan

- [x] All existing tests pass locally
- [x] Builds for `wasm32-unknown-unknown`
- [x] CI passes on all platforms (Linux x64, Linux ARM, macOS, Windows)
- [x] CI builds succeed for wasm32 and i686