### PR TITLE
resolve pi precision overflow and add test

### DIFF
--- a/astro-float-num/src/ops/consts/pi.rs
+++ b/astro-float-num/src/ops/consts/pi.rs
@@ -3,7 +3,7 @@
 use crate::common::util::round_p;
 use crate::defs::{Error, WORD_BIT_SIZE};
 use crate::num::BigFloatNumber;
-use crate::RoundingMode;
+use crate::{RoundingMode, Sign};
 
 fn pqr(a: u64, b: u64) -> Result<(BigFloatNumber, BigFloatNumber, BigFloatNumber), Error> {
     if a == b - 1 {
@@ -110,7 +110,9 @@ impl PiCache {
     /// Return value of PI with precision `k`.
     pub(crate) fn for_prec(&mut self, k: usize, rm: RoundingMode) -> Result<BigFloatNumber, Error> {
         let mut p_inc = WORD_BIT_SIZE;
-        let mut p_wrk = round_p(k) + p_inc;
+        let mut p_wrk = round_p(k)
+            .checked_add(p_inc)
+            .ok_or(Error::ExponentOverflow(Sign::Pos))?;
 
         loop {
             let kext = (k + 46 + WORD_BIT_SIZE) / 47;
@@ -151,7 +153,14 @@ impl PiCache {
 mod tests {
 
     use super::*;
-    use crate::{RoundingMode, Sign};
+    use crate::{Consts, RoundingMode, Sign};
+
+    #[test]
+    fn test_pi_precision_overflow() {
+        let mut cc = Consts::new().expect("Constants cache initialized");
+        let pi = cc.pi(u64::MAX as usize, RoundingMode::None);
+        assert!(pi.is_nan());
+    }
 
     #[test]
     #[cfg(target_pointer_width = "32")]

--- a/astro-float-num/src/ops/consts/pi.rs
+++ b/astro-float-num/src/ops/consts/pi.rs
@@ -3,7 +3,7 @@
 use crate::common::util::round_p;
 use crate::defs::{Error, WORD_BIT_SIZE};
 use crate::num::BigFloatNumber;
-use crate::{RoundingMode, Sign};
+use crate::RoundingMode;
 
 fn pqr(a: u64, b: u64) -> Result<(BigFloatNumber, BigFloatNumber, BigFloatNumber), Error> {
     if a == b - 1 {
@@ -112,7 +112,7 @@ impl PiCache {
         let mut p_inc = WORD_BIT_SIZE;
         let mut p_wrk = round_p(k)
             .checked_add(p_inc)
-            .ok_or(Error::ExponentOverflow(Sign::Pos))?;
+            .ok_or(Error::InvalidArgument)?;
 
         loop {
             let kext = (k + 46 + WORD_BIT_SIZE) / 47;


### PR DESCRIPTION
Hello! Thank you for such an amazing library - it is truly incredible.

## Issue

```rust
let precision = u64::MAX as usize; // <- will cause overflow
_ = cc.pi(precision, RoundingMode::None);
```

The code above panics with `attempt to add with overflow` for this line:

https://github.com/stencillogic/astro-float/blob/f92380e025deb8e1743ed93c6d5bf0783ac28717/astro-float-num/src/ops/consts/pi.rs#L113

## Changes

I have modified the line above to perform `checked_add` and return an `Error` if something goes wrong (as well as added a test).

```rust
let mut p_wrk = round_p(k)
    .checked_add(p_inc)
    .ok_or(Error::ExponentOverflow(Sign::Pos))?;
```

Please let me know if you have any questions, or if you would like me to make any changes to this PR (is the test in the correct file? am I returning the correct `Error`? etc..).

Thanks again!