### PR TITLE
fix: compare nonzero values above zero

### DIFF
--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -1699,6 +1699,18 @@ mod tests {
     use alloc::format;
 
     #[test]
+    fn cmp_orders_nonzero_values_against_zero() {
+        let zero = BigFloat::new(DEFAULT_P);
+        let positive = BigFloat::from_f64(0.25, DEFAULT_P);
+        let negative = BigFloat::from_f64(-0.25, DEFAULT_P);
+
+        assert_eq!(positive.cmp(&zero), Some(1));
+        assert_eq!(zero.cmp(&positive), Some(-1));
+        assert_eq!(negative.cmp(&zero), Some(-1));
+        assert_eq!(zero.cmp(&negative), Some(1));
+    }
+
+    #[test]
     fn test_ext() {
         let rm = RoundingMode::ToOdd;
         let mut cc = Consts::new().unwrap();

--- a/astro-float-num/src/num.rs
+++ b/astro-float-num/src/num.rs
@@ -770,6 +770,9 @@ impl BigFloatNumber {
                 return -1;
             }
         }
+        if d2.m.is_zero() {
+            return 1;
+        }
 
         let n1 = self.mantissa_max_bit_len() as isize - self.precision() as isize;
 


### PR DESCRIPTION
## Summary

Fixes #44.

`BigFloatNumber::abs_cmp` already handled a zero left operand, but a zero right operand fell through to adjusted-exponent comparison. That made finite positive values below 0.5 compare as less than zero.

This adds the missing nonzero-vs-zero absolute comparison branch and pins both positive and negative nonzero values against zero through the public `BigFloat::cmp` API.

## Verification

- Downstream repro against the pre-fix code returned `Some(-1)` for `BigFloat::from_f64(0.25, 256).cmp(&zero)`.
- Same downstream repro passes after the fix.
- `cargo fmt --all -- --check`
- `cargo check -p astro-float-num --lib`
- `git diff --check`

## Note

I also attempted `cargo test -p astro-float-num cmp_orders_nonzero_values_against_zero --lib -- --nocapture`; in this environment it timed out while compiling bundled `gmp-mpfr-sys` after 420 seconds, before running the test.