### PR TITLE
Fix subtraction overflow in conv_to_dec on 32-bit targets

### DIFF
--- a/astro-float-num/src/conv.rs
+++ b/astro-float-num/src/conv.rs
@@ -447,7 +447,7 @@ impl BigFloatNumber {
 
             let (mut m, _, e, inexact) = x.into_raw_parts();
 
-            let shift = e as usize - p_wrk;
+            let shift = (e as usize).saturating_sub(p_wrk);
             if shift > 0 {
                 m.shift_left_resize(shift)?;
             }

--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -2504,4 +2504,14 @@ mod rand_tests {
             assert!(n.precision().unwrap() >= p);
         }
     }
+
+    #[test]
+    fn test_format_no_overflow() {
+        let mut cc = Consts::new().unwrap();
+        for p in [1, 8, 24, 53, 64, 128, 256] {
+            let n = BigFloat::parse("1.0", Radix::Dec, p, RoundingMode::ToEven, &mut cc);
+            let s = n.format(Radix::Dec, RoundingMode::ToEven, &mut cc).unwrap();
+            assert!(s.starts_with('1'));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #43.

In `conv_to_dec` the working precision `p_wrk` can exceed the exponent `e` returned from `into_raw_parts`, so `e as usize - p_wrk` underflows and panics with "attempt to subtract with overflow" in debug builds. This shows up on 32-bit targets (the issue reports wasm32) where `p_wrk` rounds up past `e` on the first refinement iteration. The following `if shift > 0` already treats the value as `max(0, e - p_wrk)`, so switching to `saturating_sub` keeps the intended behavior and just avoids the underflow.

I verified the reporter's repro (`BigFloat::parse("1.0", ...).format(...)`) now succeeds when built for a 32-bit target, and the full test suite passes with `-C overflow-checks=on` on 64-bit. Added a regression test for formatting across a range of precisions.