### PR TITLE
Fix 32-bit decimal regression coverage and zero comparisons.

### DIFF
--- a/.github/workflows/2-tests.yml
+++ b/.github/workflows/2-tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Build for wasm32 with features
       run: cargo build --package astro-float-num --target wasm32-unknown-unknown --no-default-features --features serde
 
-  build-i686:
+  test-i686:
     runs-on: ubuntu-latest
 
     steps:
@@ -58,5 +58,7 @@ jobs:
       run: rustup target add i686-unknown-linux-gnu
     - name: Install 32-bit libs
       run: sudo apt-get update && sudo apt-get install -y gcc-multilib
-    - name: Build for i686
-      run: cargo build --package astro-float-num --target i686-unknown-linux-gnu
+    - name: Run tests for i686
+      env:
+        RUSTFLAGS: -C overflow-checks=on
+      run: cargo test --package astro-float-num --lib --release --verbose --target i686-unknown-linux-gnu

--- a/astro-float-num/src/defs.rs
+++ b/astro-float-num/src/defs.rs
@@ -32,6 +32,9 @@ pub type DoubleWord = u64;
 #[cfg(target_pointer_width = "32")]
 pub type SignedWord = i64;
 
+// Word-sized values are used as indices throughout the implementation.
+const _: [(); 1] = [(); (core::mem::size_of::<Word>() <= core::mem::size_of::<usize>()) as usize];
+
 /// An exponent.
 pub type Exponent = i32;
 

--- a/astro-float-num/src/ext.rs
+++ b/astro-float-num/src/ext.rs
@@ -1698,6 +1698,21 @@ mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::format;
 
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn test_decimal_formatting_round_trip() {
+        let mut cc = Consts::new().unwrap();
+        let p = 53;
+        let rm = RoundingMode::ToEven;
+        let value = BigFloat::parse("1.0", Radix::Dec, p, rm, &mut cc);
+
+        let formatted = value.format(Radix::Dec, rm, &mut cc).unwrap();
+        assert_eq!(formatted, "1.e+0");
+
+        let reparsed = BigFloat::parse(&formatted, Radix::Dec, p, rm, &mut cc);
+        assert_eq!(reparsed, value);
+    }
+
     #[test]
     fn test_ext() {
         let rm = RoundingMode::ToOdd;

--- a/astro-float-num/src/num.rs
+++ b/astro-float-num/src/num.rs
@@ -771,6 +771,10 @@ impl BigFloatNumber {
             }
         }
 
+        if d2.m.is_zero() {
+            return 1;
+        }
+
         let n1 = self.mantissa_max_bit_len() as isize - self.precision() as isize;
 
         let n2 = d2.mantissa_max_bit_len() as isize - d2.precision() as isize;
@@ -1684,6 +1688,15 @@ mod tests {
         d3.inv_sign();
         assert!(d3.cmp(&d1) < 0);
 
+        d1 = BigFloatNumber::from_f64(p, 0.25).unwrap();
+        d2 = BigFloatNumber::from_f64(p, 0.0).unwrap();
+        assert!(d1.cmp(&d2) > 0);
+        assert!(d2.cmp(&d1) < 0);
+        d1.inv_sign();
+        d2.inv_sign();
+        assert!(d1.cmp(&d2) < 0);
+        assert!(d2.cmp(&d1) > 0);
+
         // cmp subnormal
         d1 = BigFloatNumber::from_raw_parts(
             &[1, WORD_MAX, 1],
@@ -1748,6 +1761,15 @@ mod tests {
         assert!(d3.abs_cmp(&d1) == 0);
         d3.inv_sign();
         assert!(d3.abs_cmp(&d1) == 0);
+
+        d1 = BigFloatNumber::from_f64(p, 0.25).unwrap();
+        d2 = BigFloatNumber::from_f64(p, 0.0).unwrap();
+        assert!(d1.abs_cmp(&d2) > 0);
+        assert!(d2.abs_cmp(&d1) < 0);
+        d1.inv_sign();
+        d2.inv_sign();
+        assert!(d1.abs_cmp(&d2) > 0);
+        assert!(d2.abs_cmp(&d1) < 0);
 
         // abs cmp subnormal
         d1 = BigFloatNumber::from_raw_parts(


### PR DESCRIPTION
Credit #45 for the original comparison fix, (I just moved the test as suggested) and PR #46 for its 32-bit investigation. #40 actually fixed #43, so I just added a test that validates that.

